### PR TITLE
Fixed bug in writer at block flush due to bad compression bit

### DIFF
--- a/blocks/writer.go
+++ b/blocks/writer.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
-
 	"github.com/dgryski/go-csnappy"
 )
 
@@ -68,13 +67,15 @@ func (w *Writer) Flush() (n int, err error) {
 }
 
 func (w *Writer) flush(size int) (n int, err error) {
-	var encoding = NO_COMPRESSION
+
 	var i int
 
 	// If we have enough buffered bytes, let's compress
 	// the data and write it out to the underlying io.Writer.
 	for w.buffer.Len() > size {
+
 		block := w.buffer.Next(w.blockSize)
+		var encoding = NO_COMPRESSION
 
 		// Data is only encoded if we successfully encode the block.
 		// Otherwise the block is identified as uncompressed.


### PR DESCRIPTION
When writing events, a scope issue caused us to sometimes indicate
that a block was compressed when it wasn't. This caused the reader
to run decompression on the data and munge the output. Fixed by
altering the scope of the compression bit, and added unit test
