### PR TITLE
Remove repetitive logging

### DIFF
--- a/cluster/rest.go
+++ b/cluster/rest.go
@@ -23,7 +23,7 @@ func NewRestServer(n *Node) *RestServer {
 	rpc.RegisterName("Node", &NodeRPC{n})
 	rpc.HandleHTTP()
 
-	n.HandleFunc("/cluster/status", Log(n.clusterStatusHandler))
+	n.HandleFunc("/cluster/status", n.clusterStatusHandler)
 	n.HandleFunc("/cluster/remove/", Log(n.clusterRemoveHandler))
 
 	n.HandleFunc("/events", n.eventHandler)


### PR DESCRIPTION
We get a `GET /cluster/status` log every 10 seconds, which makes it hard to find the interesting stuff in amongst the noise.