### PR TITLE
Fixes.

### DIFF
--- a/blocks/fast_reader_test.go
+++ b/blocks/fast_reader_test.go
@@ -81,7 +81,7 @@ func TestFastReadByte(t *testing.T) {
 		found, err := r.ReadByte()
 
 		if found != expected {
-			t.Errorf("Wrong byte for Case %d: want: %s got: %s", i, expected, found)
+			t.Errorf("Wrong byte for Case %d: want: %v got: %v", i, expected, found)
 		}
 
 		if err != nil {

--- a/blocks/reader_test.go
+++ b/blocks/reader_test.go
@@ -80,7 +80,7 @@ func TestReadByte(t *testing.T) {
 		found, err := r.ReadByte()
 
 		if found != expected {
-			t.Errorf("Wrong byte for Case %d: want: %s got: %s", i, expected, found)
+			t.Errorf("Wrong byte for Case %d: want: %v got: %v", i, expected, found)
 		}
 
 		if err != nil {

--- a/event_block_writer_test.go
+++ b/event_block_writer_test.go
@@ -104,7 +104,7 @@ func TestWriteEventBlocksMedium(t *testing.T) {
 	}
 
 	if e := pullEvent(r); e != nil {
-		t.Errorf("Case %d: Found unexpected written event %v", e.Data)
+		t.Errorf("Found unexpected written event %v", e.Data)
 	}
 }
 


### PR DESCRIPTION
The reader was broken in the case of short reads (that is the reader requests 10000 bytes and only received 5000).

This is the essential fix for that.
```
// Ensure the raw scratch space contains at least `length` bytes.
func (r *Reader) ensureScratch(length uint) (err error) {
	var n int
	for uint(r.scratch.Len()) < length {
		block := make([]byte, headerLen(r.blockSize)+r.blockSize)
		n, err = r.reader.Read(block)
		if err != nil {
			return
		}
		r.scratch.Write(block[:n])
	}
	return
}
```

However, this PR also adds some performance optimizations I made in the fast reader and fixes some tests.