### PR TITLE
PRO-1043: Add FastReader.Close()

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,6 @@
+[settings]
+# needed for installing tools using go directly (go forge) as that is an experimental feature at the moment
+experimental = true
+
+[tools]
+go = '1.22.7'

--- a/.mise.toml
+++ b/.mise.toml
@@ -4,3 +4,7 @@ experimental = true
 
 [tools]
 go = '1.22.7'
+
+[tasks.test]
+alias="t"
+run = "go test -race -p 1 ./..."

--- a/blocks/fast_reader_test.go
+++ b/blocks/fast_reader_test.go
@@ -8,8 +8,10 @@ import (
 	"io"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func ExampleFastReader() {
@@ -25,14 +27,6 @@ func ExampleFastReader() {
 	// Output: "hello world"
 }
 
-func newBufioReader() interface{} {
-	return bufio.NewReaderSize(nil, 1024*1024)
-}
-
-var fileReaderPool sync.Pool = sync.Pool{
-	New: newBufioReader,
-}
-
 func TestFastRead(t *testing.T) {
 	var tests = []struct {
 		blockSize int
@@ -44,6 +38,56 @@ func TestFastRead(t *testing.T) {
 		{32, "helloworldhelloworldhelloworld", 20},
 		{2, "helloworld", 15},
 		{10, "helloworldhelloworldhelloworld", 10},
+
+		// These cases are desgined to fill the FastReader.reads
+		// buffered channel.
+		{10, strings.Repeat("helloworld", 1024), 10},
+		{10, strings.Repeat("helloworld", 2048), 10},
+		{10, strings.Repeat("helloworld", 4096), 10},
+	}
+
+	for i, test := range tests {
+		buffer := new(bytes.Buffer)
+		w := NewWriter(buffer, test.blockSize)
+
+		w.Write([]byte(test.input))
+		w.Flush()
+
+		r := NewFastReader(context.Background(), bytes.NewReader(buffer.Bytes()), test.blockSize)
+
+		var err error
+		var length int
+		result := make([]byte, 0)
+		bytes := make([]byte, test.readSize)
+		n := 1
+
+		for n > 0 && err == nil {
+			n, err = r.Read(bytes)
+			result = append(result, bytes[:n]...)
+			length += n
+		}
+
+		if !reflect.DeepEqual(result, []byte(test.input)) {
+			t.Errorf("Wrong bytes for Case %d:\n want: %x\n  got: %x", i, test.input, result)
+		}
+
+		if length != len(test.input) || err != io.EOF {
+			t.Errorf("Wrong return for Case %d: want: %d,EOF got: %d,%v", i, len(test.input), length, err)
+		}
+	}
+}
+
+func TestFastReadVsCancel(t *testing.T) {
+	var tests = []struct {
+		blockSize int
+		input     string
+		readSize  int
+	}{
+		// These cases are desgined to fill the FastReader.reads
+		// buffered channel.
+		{10, strings.Repeat("helloworld", 1024), 10},
+		{10, strings.Repeat("helloworld", 2048), 10},
+		{10, strings.Repeat("helloworld", 4096), 10},
 	}
 
 	for i, test := range tests {
@@ -54,49 +98,65 @@ func TestFastRead(t *testing.T) {
 			w.Write([]byte(test.input))
 			w.Flush()
 
-			// r := NewFastReader(context.Background(), bytes.NewReader(buffer.Bytes()), test.blockSize)
+			ctx, cancel := context.WithCancel(context.Background())
+			r := NewFastReader(ctx, bytes.NewReader(buffer.Bytes()), test.blockSize)
+			cancel()
+			time.Sleep(10 * time.Millisecond)
+			r.Close()
+		})
+	}
+}
+
+// Simulate using a pool of bufio.Reader, to reuse allocated memory
+// across multiple files. Verify that deferred cleanup is not racy.
+func TestFastReadPoolDefer(t *testing.T) {
+	var tests = []struct {
+		blockSize int
+		input     string
+		readSize  int
+	}{
+		{32, "helloworldhelloworldhelloworld", 35},
+		{32, "helloworldhelloworldhelloworld", 30},
+		{32, "helloworldhelloworldhelloworld", 20},
+		{2, "helloworld", 15},
+		{10, "helloworldhelloworldhelloworld", 10},
+
+		// These cases are desgined to fill the FastReader.reads
+		// buffered channel. This is necessary to verify that
+		// FastReader.Close() can terminate the readAhead goroutine
+		// via the done channel.
+		{10, strings.Repeat("helloworld", 1024), 10},
+		{10, strings.Repeat("helloworld", 2048), 10},
+		{10, strings.Repeat("helloworld", 4096), 10},
+	}
+
+	newBufioReader := func() interface{} {
+		return bufio.NewReaderSize(nil, 1024*1024)
+	}
+
+	var fileReaderPool sync.Pool = sync.Pool{
+		New: newBufioReader,
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			buffer := new(bytes.Buffer)
+			w := NewWriter(buffer, test.blockSize)
+
+			w.Write([]byte(test.input))
+			w.Flush()
+
 			f := bytes.NewReader(buffer.Bytes())
 			fr := fileReaderPool.Get().(*bufio.Reader)
 			fr.Reset(f)
 
-			// defer func() {
-			// 	fr.Reset(nil)
-			// 	fileReaderPool.Put(fr)
-			// }()
-
-			ctx, cancel := context.WithCancel(context.Background())
-			r := NewFastReader(ctx, fr, test.blockSize)
+			r := NewFastReader(context.Background(), fr, test.blockSize)
 
 			defer func() {
-				cancel()
 				r.Close()
 				fr.Reset(nil)
 				fileReaderPool.Put(fr)
 			}()
-
-			if true {
-				return
-			}
-
-			var err error
-			var length int
-			result := make([]byte, 0)
-			bytes := make([]byte, test.readSize)
-			n := 1
-
-			for n > 0 && err == nil {
-				n, err = r.Read(bytes)
-				result = append(result, bytes[:n]...)
-				length += n
-			}
-
-			if !reflect.DeepEqual(result, []byte(test.input)) {
-				t.Errorf("Wrong bytes for Case %d:\n want: %x\n  got: %x", i, test.input, result)
-			}
-
-			if length != len(test.input) || err != io.EOF {
-				t.Errorf("Wrong return for Case %d: want: %d,EOF got: %d,%v", i, len(test.input), length, err)
-			}
 		})
 	}
 }


### PR DESCRIPTION
`blocks.NewFastReader` starts up a read-ahead goroutine that reads from the supplied `io.Reader`. Before this PR, there was no concept of "ownership" of the `io.Reader`, or the ability to close down the `FastReader`.

This could lead to crashes in situations where the `io.Reader` such as a `bufio.Reader` was later reused.

So, add a new `FastReader.Close()` function that will terminate the read-ahead goroutine, and stop any further background reading from the `io.Reader`. `FastReader.Close()` is intended to be used from defer.

This doesn't do any other cleanup of the `FastReader`. Perhaps it should, and not allow e.g.: reads from it after a close?